### PR TITLE
Add our first test.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,6 +69,7 @@ dependencies {
   kapt 'com.google.dagger:dagger-compiler:2.13'
   implementation 'com.android.support.constraint:constraint-layout:1.0.2'
   testImplementation 'junit:junit:4.12'
+  testImplementation 'org.assertj:assertj-core:3.9.0'
   androidTestImplementation 'com.android.support.test:runner:1.0.1'
   androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 }

--- a/app/src/test/java/io/beerdeddevs/heartbeards/extension/RxExtensionsKtTest.kt
+++ b/app/src/test/java/io/beerdeddevs/heartbeards/extension/RxExtensionsKtTest.kt
@@ -1,0 +1,16 @@
+package io.beerdeddevs.heartbeards.extension
+
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.disposables.Disposables
+import org.assertj.core.api.Java6Assertions.assertThat
+import org.junit.Test
+
+class RxExtensionsKtTest {
+  @Test fun compositeDisposablePlusAssign() {
+    val compositeDisposable = CompositeDisposable()
+    assertThat(compositeDisposable.size()).isEqualTo(0)
+
+    compositeDisposable += Disposables.empty()
+    assertThat(compositeDisposable.size()).isEqualTo(1)
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.github.ben-manes.versions'
+apply plugin: 'com.vanniktech.android.junit.jacoco'
 
 buildscript {
   ext.kotlin_version = '1.2.0'
@@ -12,6 +13,7 @@ buildscript {
   dependencies {
     classpath 'com.android.tools.build:gradle:3.0.1'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
+    classpath 'com.vanniktech:gradle-android-junit-jacoco-plugin:0.11.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     classpath 'com.google.gms:google-services:3.1.2'
   }


### PR DESCRIPTION
Jacoco might be buggy here.

No coverage on root package:

<img width="1183" alt="screen shot 2018-01-05 at 13 18 00" src="https://user-images.githubusercontent.com/5759366/34608923-ef2cced8-f21a-11e7-9453-e1909f143789.png">

But then on extension package we've got:

<img width="1251" alt="screen shot 2018-01-05 at 13 18 04" src="https://user-images.githubusercontent.com/5759366/34608924-ef469d22-f21a-11e7-89a7-e35ef7f727c0.png">

@dhartwich1991 can you enable codecov so we get reports with each PR? It should just work now™